### PR TITLE
262177: Use conventions in App Config Service helm template

### DIFF
--- a/.azuredevops/publish-helm-library.yaml
+++ b/.azuredevops/publish-helm-library.yaml
@@ -26,7 +26,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: main
+      ref: features/chart-version
 
 extends:
   template: /pipelines/common-helm-library-git-publish.yaml@DEFRA-ADPPipelineCommon 

--- a/.azuredevops/publish-helm-library.yaml
+++ b/.azuredevops/publish-helm-library.yaml
@@ -26,7 +26,7 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: features/chart-version
+      ref: main
 
 extends:
   template: /pipelines/common-helm-library-git-publish.yaml@DEFRA-ADPPipelineCommon 

--- a/README.md
+++ b/README.md
@@ -165,24 +165,12 @@ containerConfigMap:
 * Template file: `_azure-config-service-map.yaml`
 * Template name: `adp-helm-library.azure-config-service-map`
 
-A K8s `ConfigMap` object object to host non-sensitive container configuration data read from the Azure Application Configuration Service.
+A K8s `ConfigMap` object to host non-sensitive container configuration data read from the Azure Application Configuration Service.
 
 A basic usage of this object template would involve the creation of `templates/azure-config-service-map.yaml` in the parent Helm chart (e.g. `ffc-microservice`) containing:
 
 ```
 {{- include "adp-helm-library.azure-config-service-map" . -}}
-```
-
-#### Required values
-
-The following values need to be set in the parent chart's `values.yaml` in addition to the globally required values [listed above](#all-template-required-values):
-
-```
-containerConfigMap:
-  name: <string>
-  configServiceUrl: <string>
-  keyValues:
-    labelFilter: <string>
 ```
 
 #### Optional values
@@ -191,15 +179,15 @@ The following value can optionally be set in the parent chart's `values.yaml`:
 
 ```
 containerConfigMap:
+  selectors:
+    - keyFilter: <string> <e.g. App1*>
+      labelFilter: <string> <e.g. Common/Shared>
   keyValues:
     keyVaults:
-      secretName: <string> <required if keyVault references are to be read from Config Service>
-      refresh: <optional>
-        interval: <duration> <e.g. 5m> <required>
+      refresh:
+        interval: <duration> <e.g. 5m>
     refresh:
-      interval: <duration> <e.g. 5m> <optional, if not specified along with the `monitorKey` default will be 30 seconds>
-      monitorKey: <string>
-      monitorLabel: <string>
+      interval: <duration> <e.g. 5m> <cannot be less than 1m if specified, default is 1m>
 ```
 
 ### Container Secret template

--- a/adp-helm-library/Chart.yaml
+++ b/adp-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-helm-library
 description: A Helm library chart that captures general configuration for the ADP Kubernetes platform
 type: library
-version: 1.0.4.1
+version: 1.0.5

--- a/adp-helm-library/Chart.yaml
+++ b/adp-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-helm-library
 description: A Helm library chart that captures general configuration for the ADP Kubernetes platform
 type: library
-version: 1.0.4
+version: 1.0.5-beta

--- a/adp-helm-library/Chart.yaml
+++ b/adp-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-helm-library
 description: A Helm library chart that captures general configuration for the ADP Kubernetes platform
 type: library
-version: 1.0.5-beta
+version: 1.0.4.1

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.containerConfigMap }}
   auth:
     workloadIdentity:
-      managedIdentityClientId: {{ .Values.containerConfigMap.configServiceMI }}
+      managedIdentityClientId: {{ .Values.containerConfigMap.configServiceMIClientId }}
   {{- end }}
   keyValues:
     selectors:
@@ -33,16 +33,10 @@ spec:
     keyVaults:
       target:
         secretName: {{ printf "%s-secret" .Values.name | quote }}
-      {{- $managedIdPrefix := (required (printf $requiredMsg "managedIdPrefix") .Values.managedIdPrefix) | lower }}
-      {{- $managedIdSuffix := .Values.name | lower }}
-      {{- $managedIdName :=  printf "%s-%s" $managedIdPrefix $managedIdSuffix }}
-      {{- $configMapName := printf "%s-mi-identity-settings" $managedIdName }}
-      {{- $configmap := (lookup "v1" "ConfigMap" .Values.namespace $configMapName) }}
-      {{- if $configmap }}
+      {{- if .Values.containerConfigMap }}
       auth:
         workloadIdentity:
-          {{- $clientId := get $configmap.data "clientId" }}
-          managedIdentityClientId: {{ $clientId }}
+          managedIdentityClientId: {{ .Values.containerConfigMap.serviceMIClientId }}
       {{- end }}
       {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.keyVaults .Values.containerConfigMap.keyValues.keyVaults.refresh }}
       refresh:

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -33,9 +33,11 @@ spec:
     keyVaults:
       target:
         secretName: {{ printf "%s-secret" .Values.name | quote }}
+      {{- if .Values.containerConfigMap }}
       auth:
         workloadIdentity:
-          managedIdentityClientId: {{ .Values.clientId }}
+          managedIdentityClientId: {{ .Values.containerConfigMap.serviceMIClientId }}
+      {{- end }}
       {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.keyVaults .Values.containerConfigMap.keyValues.keyVaults.refresh }}
       refresh:
         interval: {{ .Values.containerConfigMap.keyValues.keyVaults.refresh.interval }}

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -34,7 +34,7 @@ spec:
       target:
         secretName: {{ printf "%s-secret" .Values.name | quote }}
       {{- $managedIdPrefix := (required (printf $requiredMsg "managedIdPrefix") .Values.managedIdPrefix) | lower }}
-      {{- $managedIdSuffix := (required (printf $requiredMsg "userAssignedIdentity.managedIdName") .Values.userAssignedIdentity.managedIdName) | lower }}
+      {{- $managedIdSuffix := .Values.name | lower }}
       {{- $managedIdName :=  printf "%s-%s" $managedIdPrefix $managedIdSuffix }}
       {{- $configMapName := printf "%s-mi-identity-settings" $managedIdName }}
       {{- $configmap := (lookup "v1" "ConfigMap" .Values.namespace $configMapName) }}

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -33,11 +33,9 @@ spec:
     keyVaults:
       target:
         secretName: {{ printf "%s-secret" .Values.name | quote }}
-      {{- if .Values.containerConfigMap }}
       auth:
         workloadIdentity:
-          managedIdentityClientId: {{ .Values.containerConfigMap.serviceMIClientId }}
-      {{- end }}
+          managedIdentityClientId: {{ .Values.clientId }}
       {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.keyVaults .Values.containerConfigMap.keyValues.keyVaults.refresh }}
       refresh:
         interval: {{ .Values.containerConfigMap.keyValues.keyVaults.refresh.interval }}

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -3,54 +3,62 @@
 apiVersion: azconfig.io/v1beta1
 kind: AzureAppConfigurationProvider
 metadata:
-  name: {{ required (printf $requiredMsg "containerConfigMap.name") .Values.containerConfigMap.name | quote }}
+  name: {{ required (printf $requiredMsg "name") (printf "%s-config-map" .Values.name) | quote }}
   namespace: {{ required (printf $requiredMsg "namespace") .Values.namespace | quote }}
   labels:
     {{- include "adp-helm-library.labels" . | nindent 4 }}
 spec:
-  endpoint: {{ required (printf $requiredMsg "containerConfigMap.configServiceUrl") .Values.containerConfigMap.configServiceUrl }}
+  {{- if .Values.containerConfigMap }}
+  endpoint: {{ printf "https://%s.azconfig.io" .Values.containerConfigMap.configServiceName }}
+  {{- else}}
+  endpoint: ""
+  {{- end }}
   target:
-    configMapName: {{ required (printf $requiredMsg "containerConfigMap.name") .Values.containerConfigMap.name | quote }}
+    configMapName: {{ printf "%s-config" .Values.name | quote }}
+  {{- if .Values.containerConfigMap }}
   auth:
     workloadIdentity:
+      managedIdentityClientId: {{ .Values.containerConfigMap.configServiceMI }}
+  {{- end }}
+  keyValues:
+    selectors:
+      - keyFilter: "*"
+        labelFilter: {{ .Values.name | quote }}
+      {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.selector }}
+      {{- range $selector := $.Values.containerConfigMap.keyValues.selector }}
+      - keyFilter: {{ required (printf $requiredMsg "containerConfigMap.keyValues.selector.keyFilter") $selector.keyFilter | quote }}
+        labelFilter: {{ required (printf $requiredMsg "containerConfigMap.keyValues.selector.labelFilter") $selector.labelFilter | quote }}
+      {{- end }}
+      {{- end }}
+    keyVaults:
+      target:
+        secretName: {{ printf "%s-secret" .Values.name | quote }}
       {{- $managedIdPrefix := (required (printf $requiredMsg "managedIdPrefix") .Values.managedIdPrefix) | lower }}
       {{- $managedIdSuffix := (required (printf $requiredMsg "userAssignedIdentity.managedIdName") .Values.userAssignedIdentity.managedIdName) | lower }}
       {{- $managedIdName :=  printf "%s-%s" $managedIdPrefix $managedIdSuffix }}
       {{- $configMapName := printf "%s-mi-identity-settings" $managedIdName }}
       {{- $configmap := (lookup "v1" "ConfigMap" .Values.namespace $configMapName) }}
       {{- if $configmap }}
-      {{- $clientId := get $configmap.data "clientId" }}
-      managedIdentityClientId: {{ $clientId }}
-      {{ else }}
-      managedIdentityClientId: ''
-      {{- end }}
-  keyValues:
-    selectors:
-      - keyFilter: {{ .Values.containerConfigMap.keyValues.keyFilter | default "*" | quote }}
-        labelFilter: {{ required (printf $requiredMsg "containerConfigMap.keyValues.labelFilter") .Values.containerConfigMap.keyValues.labelFilter | quote }}
-    {{- if .Values.containerConfigMap.keyValues.keyVaults }}
-    keyVaults:
-      target:
-        secretName: {{ required (printf $requiredMsg "containerConfigMap.keyValues.keyVaults.secretName") .Values.containerConfigMap.keyValues.keyVaults.secretName | quote }}
       auth:
         workloadIdentity:
-          {{- if $configmap }}
           {{- $clientId := get $configmap.data "clientId" }}
           managedIdentityClientId: {{ $clientId }}
-          {{ else }}
-          managedIdentityClientId: ''
-          {{- end }}
-      {{- if .Values.containerConfigMap.keyValues.keyVaults.refresh }}
-      refresh:
-        interval: {{ required (printf $requiredMsg "containerConfigMap.keyValues.keyVaults.refresh.interval") .Values.containerConfigMap.keyValues.keyVaults.refresh.interval }}
       {{- end }}
-    {{- end }}
-    {{- if .Values.containerConfigMap.keyValues.refresh }}
+      {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.keyVaults .Values.containerConfigMap.keyValues.keyVaults.refresh }}
+      refresh:
+        interval: {{ .Values.containerConfigMap.keyValues.keyVaults.refresh.interval }}
+      {{- else}}
+      refresh:
+        interval: "5m"
+      {{- end }}
     refresh:
+      {{- if and .Values.containerConfigMap .Values.containerConfigMap.keyValues .Values.containerConfigMap.keyValues.refresh }}
       interval: {{ .Values.containerConfigMap.keyValues.refresh.interval }}
+      {{- else}}
+      interval: "1m"
+      {{- end}}
       monitoring:
         keyValues:
-          - key: {{ required (printf $requiredMsg "containerConfigMap.keyValues.refresh.monitorKey") .Values.containerConfigMap.keyValues.refresh.monitorKey }}
-            label: {{ required (printf $requiredMsg "containerConfigMap.keyValues.refresh.monitorLabel") .Values.containerConfigMap.keyValues.refresh.monitorLabel }}
-    {{- end }}
+          - key: "Sentinel"
+            label: {{ .Values.name }}
 {{- end }}

--- a/adp-helm-library/templates/_container.yaml
+++ b/adp-helm-library/templates/_container.yaml
@@ -3,14 +3,10 @@
 name: {{ required (printf $requiredMsg "name") .Values.name | quote }}
 image: {{ required (printf $requiredMsg "image") .Values.image | quote }}
 envFrom:
-{{- if .Values.containerConfigMap }}
 - configMapRef:
-    name: {{ .Values.containerConfigMap.name }}
-{{- end }}
-{{- if .Values.containerSecret }}
+    name: {{ printf "%s-config" .Values.name | quote }}
 - secretRef:
-    name: {{ .Values.containerSecret.name }}
-{{- end }}
+    name: {{ printf "%s-secret" .Values.name | quote }}
 {{- if .Values.container.command }}
 command:
   {{- toYaml .Values.container.command | nindent 12 }}

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->
+
+# **What this PR does / why we need it**:
+*A brief description of changes being made*
+*Link to the relevant work items: e.g: Relates to ADO Work Item AB#213700 and builds on #3376 (link to ADO Build ID URL)*
+
+# **Special notes for your reviewer**
+*Any specific actions or notes on review?*
+
+# Testing
+*Any relevant testing information and pipeline runs.*
+
+# Checklist (please delete before completing or setting auto-complete)
+- [ ] Story Work items associated (not Tasks)
+- [ ] Successful testing run(s) link provided
+- [ ] Title pattern should be `{work item number}: {title}`
+- [ ] Description covers all the changes in the PR
+- [ ] This PR contains documentation
+- [ ] This PR contains tests
+
+
+# **How does this PR make you feel**:
+![gif](https://giphy.com/)


### PR DESCRIPTION
# **What this PR does / why we need it**:
Refactor the helm template to use conventions to build the information for the app config service provider.
Relates to ADO Work Item [AB#262177](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/262177)

# **Special notes for your reviewer**
N/A

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/M6beiAhOPVLKUGnB1G/giphy.gif)