### PR TITLE
286235: Abstracting Memory and CPU Requests/Limits from flux-services into ADP-helm-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,19 +113,53 @@ The following values need to be set in the parent chart's `values.yaml` in addit
 
 ```
 image: <string>
-container:  
-  requestMemory: <string>
-  requestCpu: <string>
-  limitMemory: <string>
-  limitCpu: <string>
+container: {}
 ```
 
 #### Optional values
+
+The following values can optionally be set in the parent chart's `values.yaml` to select the required CPU and Memory for a container:
+
+```
+container:
+  memCpuTier: <string S|M|L|XL|XXL|CUSTOM>
+  requestMemory: <string - REQUIRED if memCpuTier is CUSTOM>
+  requestCpu: <string - REQUIRED if memCpuTier is CUSTOM>
+  limitMemory: <string - REQUIRED if memCpuTier is CUSTOM>
+  limitCpu: <string - REQUIRED if memCpuTier is CUSTOM>
+```
+
+Please see memCpuTier values in the below table:
+
+| TIER   | CPU-REQUEST | CPU-LIMIT | MEMORY-REQUEST | MEMORY-LIMIT |
+| ------ | ----------- | --------- | -------------- | ------------ |
+| S      | 50m         | 50m       | 50Mi           | 50Mi         |
+| M      | 100m        | 100m      | 100Mi          | 100Mi        |
+| L      | 150m        | 150m      | 150Mi          | 150Mi        |
+| XL     | 200m        | 200m      | 200Mi          | 200Mi        |
+| XXL    | 300m        | 600m      | 300Mi          | 600Mi        |
+| CUSTOM | <?>         | <?>       | <?>            | <?>          |
+
+NOTE: 
+If you do not add a 'memCpuTier' then the Tier will default to 'M'
+
+NOTE: 
+You can also choose CUSTOM and provide your own values if the TIER sizes don't fit your requirements.
+If you choose CUSTOM, requestMemory, requestCpu, limitMemory and limitCpu are required.
+
+IMPORTANT: 
+Your team namespace will be given a fixed amount of resources via ResourceQuotas.  
+Once your cumulative resource request total passes the assigned quota on your namespace, all further deployments will be unsuccessful.  If you require an increase to your ResourceQuota, you will need to raise a request via the ADP team.  It's important you monitor the performance of your application and adjust pod requests and limits accordingly.  Please choose the appropriate cpu and memory tier for your application or provide custom values for your CPU and Memory requests and limits.
 
 The following values can optionally be set in the parent chart's `values.yaml` to enable a command with arguments to run within the container or change the security context:
 
 ```
 container:
+  memCpuTier: <string S|M|L|XL|XXL|CUSTOM>
+  requestMemory: <string - REQUIRED if memCpuTier is CUSTOM>
+  requestCpu: <string - REQUIRED if memCpuTier is CUSTOM>
+  limitMemory: <string - REQUIRED if memCpuTier is CUSTOM>
+  limitCpu: <string - REQUIRED if memCpuTier is CUSTOM>
   imagePullPolicy: <string>
   command: <list of strings>
   args: <list of strings>

--- a/README.md
+++ b/README.md
@@ -155,11 +155,6 @@ The following values can optionally be set in the parent chart's `values.yaml` t
 
 ```
 container:
-  memCpuTier: <string S|M|L|XL|XXL|CUSTOM>
-  requestMemory: <string - REQUIRED if memCpuTier is CUSTOM>
-  requestCpu: <string - REQUIRED if memCpuTier is CUSTOM>
-  limitMemory: <string - REQUIRED if memCpuTier is CUSTOM>
-  limitCpu: <string - REQUIRED if memCpuTier is CUSTOM>
   imagePullPolicy: <string>
   command: <list of strings>
   args: <list of strings>

--- a/adp-helm-library/Chart.yaml
+++ b/adp-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-helm-library
 description: A Helm library chart that captures general configuration for the ADP Kubernetes platform
 type: library
-version: 1.0.8
+version: 1.0.9

--- a/adp-helm-library/templates/_container.yaml
+++ b/adp-helm-library/templates/_container.yaml
@@ -20,12 +20,7 @@ securityContext:
   readOnlyRootFilesystem: {{ .Values.container.readOnlyRootFilesystem | default true }}
   allowPrivilegeEscalation: {{ .Values.container.allowPrivilegeEscalation | default false }}
 resources:
-  requests:
-    memory: {{ required (printf $requiredMsg "container.requestMemory") .Values.container.requestMemory | quote }}
-    cpu: {{ required (printf $requiredMsg "container.requestCpu") .Values.container.requestCpu | quote }}
-  limits:
-    memory: {{ required (printf $requiredMsg "container.limitMemory") .Values.container.limitMemory | quote }}
-    cpu: {{ required (printf $requiredMsg "container.limitCpu") .Values.container.limitCpu | quote }}
+  {{ include "adp-helm-library.mem-cpu-tiers" $ }}
 volumeMounts:
 - mountPath: /tmp
   name: temp-dir

--- a/adp-helm-library/templates/_helpers.tpl
+++ b/adp-helm-library/templates/_helpers.tpl
@@ -24,39 +24,39 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- $requiredMsg := include "adp-helm-library.default-check-required-msg" . -}}
 {{- $memCpuTier := $.Values.container.memCpuTier }}
 
-{{- $requestsMemory := "50mi" }}
+{{- $requestsMemory := "50Mi" }}
 {{- $requestsCpu := "50m" }}
-{{- $limitsMemory := "50mi" }}
+{{- $limitsMemory := "50Mi" }}
 {{- $limitsCpu := "50m" }}
 
 {{- if eq $memCpuTier "S" }}
-{{- $requestsMemory = "50mi" }}
+{{- $requestsMemory = "50Mi" }}
 {{- $requestsCpu = "50m" }}
-{{- $limitsMemory = "50mi" }}
+{{- $limitsMemory = "50Mi" }}
 {{- $limitsCpu = "50m" }}
 
 {{- else if eq $memCpuTier "M" }}
-{{- $requestsMemory = "100mi" }}
+{{- $requestsMemory = "100Mi" }}
 {{- $requestsCpu = "100m" }}
-{{- $limitsMemory = "100mi" }}
+{{- $limitsMemory = "100Mi" }}
 {{- $limitsCpu = "100m" }}
 
 {{- else if eq $memCpuTier "L" }}
-{{- $requestsMemory = "150mi" }}
+{{- $requestsMemory = "150Mi" }}
 {{- $requestsCpu = "150m" }}
-{{- $limitsMemory = "150mi" }}
+{{- $limitsMemory = "150Mi" }}
 {{- $limitsCpu = "150m" }}
 
 {{- else if eq $memCpuTier "XL" }}
-{{- $requestsMemory = "200mi" }}
+{{- $requestsMemory = "200Mi" }}
 {{- $requestsCpu = "200m" }}
-{{- $limitsMemory = "200mi" }}
+{{- $limitsMemory = "200Mi" }}
 {{- $limitsCpu = "200m" }}
 
 {{- else if eq $memCpuTier "XXL" }}
-{{- $requestsMemory = "200mi" }}
+{{- $requestsMemory = "200Mi" }}
 {{- $requestsCpu = "200m" }}
-{{- $limitsMemory = "500mi" }}
+{{- $limitsMemory = "500Mi" }}
 {{- $limitsCpu = "500m" }}
 
 {{- else if eq $memCpuTier "CUSTOM" }}

--- a/adp-helm-library/templates/_helpers.tpl
+++ b/adp-helm-library/templates/_helpers.tpl
@@ -20,6 +20,62 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end -}}
 
+{{- define "adp-helm-library.mem-cpu-tiers" -}}
+{{- $requiredMsg := include "adp-helm-library.default-check-required-msg" . -}}
+{{- $memCpuTier := $.Values.container.memCpuTier }}
+
+{{- $requestsMemory := "50mi" }}
+{{- $requestsCpu := "50m" }}
+{{- $limitsMemory := "50mi" }}
+{{- $limitsCpu := "50m" }}
+
+{{- if eq $memCpuTier "S" }}
+{{- $requestsMemory = "50mi" }}
+{{- $requestsCpu = "50m" }}
+{{- $limitsMemory = "50mi" }}
+{{- $limitsCpu = "50m" }}
+
+{{- else if eq $memCpuTier "M" }}
+{{- $requestsMemory = "100mi" }}
+{{- $requestsCpu = "100m" }}
+{{- $limitsMemory = "100mi" }}
+{{- $limitsCpu = "100m" }}
+
+{{- else if eq $memCpuTier "L" }}
+{{- $requestsMemory = "150mi" }}
+{{- $requestsCpu = "150m" }}
+{{- $limitsMemory = "150mi" }}
+{{- $limitsCpu = "150m" }}
+
+{{- else if eq $memCpuTier "XL" }}
+{{- $requestsMemory = "200mi" }}
+{{- $requestsCpu = "200m" }}
+{{- $limitsMemory = "200mi" }}
+{{- $limitsCpu = "200m" }}
+
+{{- else if eq $memCpuTier "XXL" }}
+{{- $requestsMemory = "200mi" }}
+{{- $requestsCpu = "200m" }}
+{{- $limitsMemory = "500mi" }}
+{{- $limitsCpu = "500m" }}
+
+{{- else if eq $memCpuTier "CUSTOM" }}
+{{- $requestsMemory = required (printf $requiredMsg "container.requestMemory") .Values.container.requestMemory | quote }}
+{{- $requestsCpu = required (printf $requiredMsg "container.requestCpu") .Values.container.requestCpu | quote }}
+{{- $limitsMemory = required (printf $requiredMsg "container.limitMemory") .Values.container.limitMemory | quote }}
+{{- $limitsCpu = required (printf $requiredMsg "container.limitCpu") .Values.container.limitCpu | quote }}
+
+{{- else }}
+{{- fail (printf "Value for memCpuTier is not as expected. '%s' memCpuTier is not in the allowed memCpuTiers (S,M,X,XL,XXL,CUSTOM)." $memCpuTier) }}
+{{- end }}
+  requests:
+    memory: {{ $requestsMemory }}
+    cpu: {{ $requestsCpu }}
+  limits:
+    memory: {{ $limitsMemory }}
+    cpu: {{ $limitsCpu }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}

--- a/adp-helm-library/templates/_helpers.tpl
+++ b/adp-helm-library/templates/_helpers.tpl
@@ -20,14 +20,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end -}}
 
+{{/*
+CPU and Memory requests and limits Tiers
+*/}}
 {{- define "adp-helm-library.mem-cpu-tiers" -}}
 {{- $requiredMsg := include "adp-helm-library.default-check-required-msg" . -}}
-{{- $memCpuTier := $.Values.container.memCpuTier }}
+{{- $memCpuTier := $.Values.container.memCpuTier | default "M" }}
 
-{{- $requestsMemory := "50Mi" }}
-{{- $requestsCpu := "50m" }}
-{{- $limitsMemory := "50Mi" }}
-{{- $limitsCpu := "50m" }}
+{{- $requestsMemory := "" }}
+{{- $requestsCpu := "" }}
+{{- $limitsMemory := "" }}
+{{- $limitsCpu := "" }}
 
 {{- if eq $memCpuTier "S" }}
 {{- $requestsMemory = "50Mi" }}
@@ -54,10 +57,10 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- $limitsCpu = "200m" }}
 
 {{- else if eq $memCpuTier "XXL" }}
-{{- $requestsMemory = "200Mi" }}
-{{- $requestsCpu = "200m" }}
-{{- $limitsMemory = "500Mi" }}
-{{- $limitsCpu = "500m" }}
+{{- $requestsMemory = "300Mi" }}
+{{- $requestsCpu = "300m" }}
+{{- $limitsMemory = "600Mi" }}
+{{- $limitsCpu = "600m" }}
 
 {{- else if eq $memCpuTier "CUSTOM" }}
 {{- $requestsMemory = required (printf $requiredMsg "container.requestMemory") .Values.container.requestMemory | quote }}


### PR DESCRIPTION
There is a requirement to abstract Memory and CPU Requests/Limits from flux-services into ADP-helm-library.  This change introduces Memory and CPU Tiers to make it easier for the development teams to onboard.  The readme file contains details of required values for the memory and cpu tiers.

The Tiers are set as below:
![image](https://github.com/DEFRA/adp-helm-library/assets/39670555/79b767e9-5edf-463b-84c4-28970740b4eb)

[AB#286235](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/286235)

# Testing
The changes have been tested against SND1 and all flux manifests have reconciled successfully.

![image](https://github.com/DEFRA/adp-infrastructure-core/assets/39670555/7a71117e-2d00-4f34-954c-53311da68823)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/nHGNPm1qyxrolTCcDn/giphy.gif)