### PR TITLE
307421: Add tags to deployment template for reloader support

### DIFF
--- a/adp-helm-library/Chart.yaml
+++ b/adp-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: adp-helm-library
 description: A Helm library chart that captures general configuration for the ADP Kubernetes platform
 type: library
-version: 1.0.13
+version: 1.0.14

--- a/adp-helm-library/templates/_azure-config-service-map.yaml
+++ b/adp-helm-library/templates/_azure-config-service-map.yaml
@@ -43,6 +43,8 @@ spec:
         keyValues:
           - key: "Sentinel"
             label: {{ .Values.name }}
+          - key: "Sentinel"
+            label: {{ printf "%s-%s" .Values.name .Chart.Version }}
   secret:
     target:
       secretName: {{ printf "%s-secret" .Values.name | quote }}

--- a/adp-helm-library/templates/_deployment.yaml
+++ b/adp-helm-library/templates/_deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ required (printf $requiredMsg "namespace") .Values.namespace | quote }}
   labels:
     {{- include "adp-helm-library.labels" . | nindent 4 }}
+  annotations:
+    configmap.reloader.stakater.com/reload: {{ printf "%s-config" .Values.name | quote }}
+    secret.reloader.stakater.com/reload: {{ printf "%s-secret" .Values.name | quote }}
 spec:
   replicas: {{ .Values.deployment.replicas | default 1 }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds | default 0 }}


### PR DESCRIPTION
# **What this PR does / why we need it**:
Add reloader tags to the deployment template for recycling the pods on configuration variables change.
Relates to ADO Work Item [AB#307421](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/307421)

# **Special notes for your reviewer**
N/A

# Testing
N/A

# **How does this PR make you feel**:
![gif](https://giphy.com/)